### PR TITLE
A few more numba optimizations

### DIFF
--- a/forcepho/likelihood.py
+++ b/forcepho/likelihood.py
@@ -192,7 +192,7 @@ class WorkPlan(object):
         time (like on a GPU)
         """
         for i, gig in enumerate(self.active):
-            for j, g in enumerate(gig.gaussians.flat):
+            for j, g in enumerate(gig.gaussians):
                 # get the image counts and gradients for each Gaussian in a GaussianGalaxy
                 I, dI_dphi = compute_gaussian(g, self.stamp.xpix.reshape(-1), self.stamp.ypix.reshape(-1),
                                               **self.compute_keywords)
@@ -252,14 +252,14 @@ class FastWorkPlan(WorkPlan):
         """
         # Loop over active and fixed to get the residual image
         for i, gig in enumerate(self.active + self.fixed):
-            for j, g in enumerate(gig.gaussians.flat):
+            for j, g in enumerate(gig.gaussians):
                 # get the image counts for each Gaussian in a GaussianGalaxy
                 self.compute_keywords['compute_deriv'] = False
                 self.residual -= compute_gaussian(g, self.stamp.xpix.flat, self.stamp.ypix.flat,
                                                   **self.compute_keywords)
         # Loop only over active to get the chisq gradients
         for i, gig in enumerate(self.active):
-            for j, g in enumerate(gig.gaussians.flat):
+            for j, g in enumerate(gig.gaussians):
                 self.compute_keywords['compute_deriv'] = True
                 # get the image gradients for each Gaussian in a GaussianGalaxy
                 I, dI_dphi = compute_gaussian(g, self.stamp.xpix.flat, self.stamp.ypix.flat,


### PR DESCRIPTION
Added a `fast_matmul_matmul_2x2()` for chained `matmul`s that broadcasts correctly, and changed `GaussianImageGalaxy.gaussians` to a 1D structure at @bd-j's suggestion.  I'm using a list instead of a Numpy array (since the Numba code actually produces a list of jitclass), but that could be changed back to an ndarray of objects pretty easily if needed.

This speeds up `convert_to_gaussians()` a little bit, from 104 µs to 90 µs.