### PR TITLE
Double chi2

### DIFF
--- a/forcepho/compute_gaussians_kernel.cu
+++ b/forcepho/compute_gaussians_kernel.cu
@@ -176,12 +176,12 @@ typedef struct {
     matrix22 scovar_im; 
     
     //some distortions and astrometry specific to ??source??. 
-    float flux; 
-    float G; 
+    float flux;
+    float G;
     float da_dn;
     float da_dr;
-    matrix22 CW; 
-    matrix22 T; 
+    matrix22 CW;
+    matrix22 T;
     matrix22 dT_dq;
     matrix22 dT_dpa;
 } PixGaussian; 
@@ -340,7 +340,7 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
 
 class Accumulator {
   public:
-    ChiFloat chi2;
+    double chi2;
     float dchi2_dp[NPARAMS*MAXSOURCES]; 
         //OPTION: Figure out how to make this not compile time.
 
@@ -350,7 +350,7 @@ class Accumulator {
 
     __device__ void zero() {
         if (threadIdx.x==0) chi2 = 0.0;
-        for (int j=threadIdx.x; j<NPARAMS*MAXSOURCES; j+=blockDim.x) dchi2_dp[j] = 0.0;
+        for (int j=threadIdx.x; j<NPARAMS*MAXSOURCES; j+=blockDim.x) dchi2_dp[j] = 0.0f;
         __syncthreads();
     }
 
@@ -476,15 +476,15 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
             data *= ierr;
             // below computes (r^2 - d^2) / sigma^2 in an attempt to decrease the size of the
             // residual and avoid loss of significance 
-            ChiFloat chi2 = (residual - data);
+            float chi2 = (residual - data);
             chi2 *= (residual + data);
             // chi2 -= 36.9;
-            accum[accumnum].SumChi2(chi2);
+            accum[accumnum].SumChi2((double) chi2);
             residual *= ierr;   // We want res*ierr^2 for the derivatives
 
             // Now we loop over Sources and compute the derivatives for each
             for (int gal = 0; gal < n_sources; gal++) {
-                for (int j=0; j<NPARAMS; j++) dchi2_dp[j]=0.0;
+                for (int j=0; j<NPARAMS; j++) dchi2_dp[j]=0.0f;
                 ComputeGaussianDerivative(xp, yp, residual,  //1.
                         imageGauss+gal*n_gal_gauss, dchi2_dp, n_gal_gauss);  
 

--- a/forcepho/compute_gaussians_kernel.cu
+++ b/forcepho/compute_gaussians_kernel.cu
@@ -340,7 +340,7 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
 
 class Accumulator {
   public:
-    float chi2;
+    ChiFloat chi2;
     float dchi2_dp[NPARAMS*MAXSOURCES]; 
         //OPTION: Figure out how to make this not compile time.
 
@@ -476,7 +476,7 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
             data *= ierr;
             // below computes (r^2 - d^2) / sigma^2 in an attempt to decrease the size of the
             // residual and avoid loss of significance 
-            float chi2 = (residual - data);
+            ChiFloat chi2 = (residual - data);
             chi2 *= (residual + data);
             // chi2 -= 36.9;
             accum[accumnum].SumChi2(chi2);

--- a/forcepho/compute_gaussians_kernel.cu
+++ b/forcepho/compute_gaussians_kernel.cu
@@ -485,9 +485,11 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
             residual *= ierr;   // Form residual/sigma, which is chi
             data *= ierr;
             // below computes (r^2 - d^2) / sigma^2 in an attempt to decrease the size of the
-            // residual and avoid loss of significance 
-            double chi2 = (residual - data);
-            chi2 *= (residual + data);
+            // residual and avoid loss of significance
+            // promoting to double on the right hand side only modestly increases the precision,
+            // but also does not measureably impact the timing
+            double chi2 = ((double) residual - (double) data);
+            chi2 *= ((double) residual + (double) data);
             // chi2 -= 36.9;
             accum[accumnum].SumChi2(chi2);
             residual *= ierr;   // We want res*ierr^2 for the derivatives

--- a/forcepho/header.hh
+++ b/forcepho/header.hh
@@ -20,7 +20,6 @@
 //#include "CudaErrors.cuh"
 
 typedef float PixFloat;
-typedef double ChiFloat;
 
 
 #endif

--- a/forcepho/header.hh
+++ b/forcepho/header.hh
@@ -20,7 +20,7 @@
 //#include "CudaErrors.cuh"
 
 typedef float PixFloat;
-
+typedef double ChiFloat;
 
 
 #endif

--- a/forcepho/model.py
+++ b/forcepho/model.py
@@ -71,7 +71,7 @@ class Posterior:
     def residuals(self, z):
         raise(NotImplementedError)
 
-    def check_grad(self, z, dlnz=1e-6):
+    def check_grad(self, z, delta=1e-5):
         """Compare numerical gradients to analytic gradients.
 
         Parameters
@@ -79,8 +79,8 @@ class Posterior:
         z : ndarray, shape (ndim,)
             The parameter location at which to check gradients
 
-        dlnz : float, optional, default=1e-6
-            Fractional change in parameter values to use for calculating
+        delta : float or ndarray, optional, default=1e-5
+            Change in parameter values to use for calculating
             numerical gradients
 
         Returns
@@ -94,7 +94,7 @@ class Posterior:
         z0 = z.copy()
         dlnp = self.lnprob_grad(z)
 
-        delta = z0 * 1e-4
+        delta = np.zeros_like(dlnp) + delta
         dlnp_num = np.zeros(len(z0), dtype=np.float64)
         for i, dp in enumerate(delta):
             theta = z0.copy()

--- a/forcepho/proposal.py
+++ b/forcepho/proposal.py
@@ -49,8 +49,8 @@ class Proposer:
 
         options = ['-std=c++11']
 
-        if chi_dtype is np.float64:
-            options += ["-arch sm_70"]
+        #if chi_dtype is np.float64:
+        #    options += ["-arch sm_70"]
 
         if show_ptxas:
             options += ['--ptxas-options=-v']

--- a/forcepho/proposal.py
+++ b/forcepho/proposal.py
@@ -33,7 +33,7 @@ class Proposer:
 
     def __init__(self, patch, thread_block=1024, shared_size=48000,
                  max_registers=64, show_ptxas=False, debug=False,
-                 kernel_name='EvaluateProposal', chi_dtype=np.float32,
+                 kernel_name='EvaluateProposal', chi_dtype=np.float64,
                  kernel_fn='compute_gaussians_kernel.cu'):
 
         self.grid = (patch.n_bands, 1)

--- a/forcepho/proposal.py
+++ b/forcepho/proposal.py
@@ -33,12 +33,13 @@ class Proposer:
 
     def __init__(self, patch, thread_block=1024, shared_size=48000,
                  max_registers=64, show_ptxas=False, debug=False,
-                 kernel_name='EvaluateProposal',
+                 kernel_name='EvaluateProposal', chi_dtype=np.float32,
                  kernel_fn='compute_gaussians_kernel.cu'):
 
         self.grid = (patch.n_bands, 1)
         self.block = (thread_block, 1, 1)
         self.shared_size = shared_size
+        self.chi_dtype = chi_dtype
         self.patch = patch
 
         thisdir = os.path.abspath(os.path.dirname(__file__))
@@ -47,6 +48,9 @@ class Proposer:
             kernel_source = fp.read()
 
         options = ['-std=c++11']
+
+        if chi_dtype is np.float64:
+            options += ["-arch sm_70"]
 
         if show_ptxas:
             options += ['--ptxas-options=-v']
@@ -85,7 +89,7 @@ class Proposer:
             Only returned if patch.return_residual.
         """
 
-        chi_out = np.empty(self.patch.n_bands, dtype=np.float32)
+        chi_out = np.empty(self.patch.n_bands, dtype=self.chi_dtype)
         chi_derivs_out = np.empty(self.patch.n_bands,
                                   dtype=response_struct_dtype)
 


### PR DESCRIPTION
use doubles for calculation and accumulation of chi2 values on the GPU.  This does not measurably increase compute time.