### PR TITLE
Distort

### DIFF
--- a/forcepho/patches/jades_patch.py
+++ b/forcepho/patches/jades_patch.py
@@ -178,8 +178,8 @@ class JadesPatch(Patch):
 
         self.D = np.empty((self.n_exp, self.n_sources, 2, 2), dtype=dtype)
         self.CW = np.empty((self.n_exp, self.n_sources, 2, 2), dtype=dtype)
-        self.crpix = np.empty((self.n_exp, 2), dtype=dtype)
-        self.crval = np.empty((self.n_exp, 2), dtype=dtype)
+        self.crpix = np.empty((self.n_exp, self.n_sources, 2), dtype=dtype)
+        self.crval = np.empty((self.n_exp, self.n_sources, 2), dtype=dtype)
         # FIXME: this is a little hacky;
         # what if zerocoords hasn't been called after the scene changed?
         ra0, dec0 = self.patch_reference_coordinates
@@ -189,16 +189,16 @@ class JadesPatch(Patch):
             # near the center of a patch
             # TODO: Source specific crpix, crval pairs?
             # Using ref coords of patch for crval and zero-indexed crpix
-            self.crval[j] = np.zeros(2, dtype=self.meta_dtype)
-            self.crpix[j] = wcs.all_world2pix(ra0, dec0, 0)
+            #self.crval[j] = np.zeros(2, dtype=self.meta_dtype)
+            #self.crpix[j] = wcs.all_world2pix(ra0, dec0, 0)
             for i, s in enumerate(scene.sources):
                 ssky = np.array([s.ra + ra0, s.dec + dec0])
                 CW_mat, D_mat = scale_at_sky(ssky, wcs)
                 self.D[j, i] = D_mat
                 self.CW[j, i] = CW_mat
                 # source specific:
-                #self.crval[j, i] = ssky - self.patch_reference_coordinates
-                #self.crpix[j, i] = wcs.all_world2pix(ssky[0], ssky[1], origin=0)
+                self.crval[j, i] = ssky - self.patch_reference_coordinates
+                self.crpix[j, i] = wcs.all_world2pix(ssky[0], ssky[1], origin=0)
 
     def _pack_fluxcal(self, hdrs, tweakphot=None, dtype=None):
         """A nominal flux calibrartion has been applied to all images,

--- a/forcepho/patches/jades_patch.py
+++ b/forcepho/patches/jades_patch.py
@@ -198,7 +198,7 @@ class JadesPatch(Patch):
                 self.CW[j, i] = CW_mat
                 # source specific:
                 self.crval[j, i] = ssky - self.patch_reference_coordinates
-                self.crpix[j, i] = wcs.all_world2pix(ssky[0], ssky[1], origin=0)
+                self.crpix[j, i] = wcs.all_world2pix(ssky[0], ssky[1], self.wcs_origin)
 
     def _pack_fluxcal(self, hdrs, tweakphot=None, dtype=None):
         """A nominal flux calibrartion has been applied to all images,

--- a/forcepho/patches/patch.py
+++ b/forcepho/patches/patch.py
@@ -128,8 +128,8 @@ class Patch:
 
         - self.D             [NEXP, NSOURCE, 2, 2]
         - self.CW            [NEXP, NSOURCE, 2, 2]
-        - self.crpix         [NEXP, 2]
-        - self.crval         [NEXP, 2]
+        - self.crpix         [NEXP, NSOURCE, 2]
+        - self.crval         [NEXP, NSOURCE, 2]
         - self.G             [NEXP]
 
         - self.n_psf_per_source  [NBAND]  number of PSFGaussians per source in each band
@@ -166,9 +166,8 @@ class Patch:
         # Each source need different astrometry for each exposure
         self.D = np.empty((n_exp, self.n_sources, 2, 2), dtype=self.meta_dtype)
         self.CW = np.empty((n_exp, self.n_sources, 2, 2), dtype=self.meta_dtype)
-        # TODO this should also be (Nexp, N_sources, 2)
-        self.crpix = np.empty((n_exp, 2), dtype=self.meta_dtype)
-        self.crval = np.empty((n_exp, 2), dtype=self.meta_dtype)
+        self.crpix = np.empty((n_exp, self.n_sources, 2), dtype=self.meta_dtype)
+        self.crval = np.empty((n_exp, self.n_sources, 2), dtype=self.meta_dtype)
         self.G = np.empty((n_exp), dtype=self.meta_dtype)
 
         # --- PSF data ---

--- a/forcepho/patches/static_patch.py
+++ b/forcepho/patches/static_patch.py
@@ -220,17 +220,17 @@ class StaticPatch(Patch):
         # Each source need different astrometry for each exposure
         self.D = np.empty((self.n_exp, self.n_sources, 2, 2), dtype=dtype)
         self.CW = np.empty((self.n_exp, self.n_sources, 2, 2), dtype=dtype)
-        self.crpix = np.empty((self.n_exp, 2), dtype=dtype)
-        self.crval = np.empty((self.n_exp, 2), dtype=dtype)
+        self.crpix = np.empty((self.n_exp, self.n_sources, 2), dtype=dtype)
+        self.crval = np.empty((self.n_exp, self.n_sources, 2), dtype=dtype)
         self.G = np.empty((self.n_exp), dtype=dtype)
 
         # The ordering of the astrometric information in the sources is
         # guaranteed to be in the same order as our exposures
 
         for i in range(self.n_exp):
-            # these values are per-exposure
-            self.crpix[i] = sources[0].stamp_crpixs[i]
-            self.crval[i] = sources[0].stamp_crvals[i]
+            # we give the same value to every source in the exp (no distortions)
+            self.crpix[i, :, :] = sources[0].stamp_crpixs[i]
+            self.crval[i, :, :] = sources[0].stamp_crvals[i]
             self.G[i] = sources[0].stamp_zps[i]
 
             for s, source in enumerate(sources):
@@ -322,15 +322,15 @@ def patch_to_stamps(patch):
         stamp.ierr = splits[3][e]
 
         # Add metadata from first source
-        stamp.crpix = patch.crpix[e]
-        stamp.crpix = patch.crval[e]
+        stamp.crpix = patch.crpix[e, 0]
+        stamp.crpix = patch.crval[e, 0]
 
     scene = patch.scene
     for s, source in enumerate(scene.sources):
         source.stamp_scales = patch.D[:, s, :, :]
         source.stamp_cds = patch.CW[:, s, :, :]  # dpix/dra, dpix/ddec
-        source.stamp_crpixs = patch.crpix[:]
-        source.stamp_crvals = patch.crval[:]
+        source.stamp_crpixs = patch.crpix[:, 0, :]
+        source.stamp_crvals = patch.crval[:, 0, :]
         source.stamp_zps = patch.G[:]
 
         # need to do something about PSFs and about Band ids

--- a/forcepho/src/compute_gaussians_kernel.cu
+++ b/forcepho/src/compute_gaussians_kernel.cu
@@ -262,7 +262,7 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
 
     // We're going to store some values common to the exposure in shared memory
     __shared__ int band, psfgauss_start, n_psf_per_source, n_gal_gauss;
-    __shared__ float G //, crpix[2], crval[2];
+    __shared__ float G; //, crpix[2], crval[2];
 
     // Load the shared values
     if ( threadIdx.x == 0 ){
@@ -310,8 +310,8 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
         // Source dependent coordinate reference values
         float crpix[2], crval[2];
         int cr_start = 2 * (patch->n_sources * exposure + g);
-        crpix = patch->crpix+cr_start;
-        crval = patch->crval+cr_start;
+        crpix[0] = patch->crpix[cr_start]; crpix[1] = patch->crpix[cr_start+1];
+        crval[0] = patch->crval[cr_start]; crval[1] = patch->crval[cr_start+1];
 
         float smean[2];
         smean[0] = galaxy->ra  - crval[0];

--- a/forcepho/src/compute_gaussians_kernel.cu
+++ b/forcepho/src/compute_gaussians_kernel.cu
@@ -23,12 +23,12 @@ For each exposure:
             Loop over Gaussian in this Galaxy:
                 Compute local_dchi_dp and accumulate
             Reduce local_dchi_dp over warp and atomic_add to shared dchi_dp for galaxy
-            
+
 When done with all exposures, copy the accumulators to the output buffer.
 */
 // Shared memory is arranged in 32 banks of 4 byte stagger
 
-//=============================================================================== 
+//===============================================================================
 
 
 #include "header.hh"
@@ -41,12 +41,12 @@ class ImageGaussian {
   public:
     // 6 Gaussian parameters
     float amp;
-    float xcen; 
+    float xcen;
     float ycen;
-    float fxx; 
+    float fxx;
     float fyy;
-    float fxy; 
-    
+    float fxy;
+
     // 15 Jacobian elements (Image -> Sky)
     float dA_dFlux;
     float dx_dAlpha;
@@ -78,11 +78,11 @@ __device__ PixFloat ComputeResidualImage(float xp, float yp, PixFloat data, Imag
 {
 
     PixFloat residual = data;
-    
-    //loop over all image gaussians g for all galaxies. 
+
+    //loop over all image gaussians g for all galaxies.
     for (int i = 0; i < n_gauss_total; i++, g++){
         // ImageGaussian *g = imageGauss+i;  // Now implicit in g++
-        float dx = xp - g->xcen; 
+        float dx = xp - g->xcen;
         float dy = yp - g->ycen;
 
         float vx = g->fxx * dx + g->fxy * dy;
@@ -93,10 +93,10 @@ __device__ PixFloat ComputeResidualImage(float xp, float yp, PixFloat data, Imag
         float Gp = expf(-0.5f * exparg);
 
         // Here are the second-order corrections to the pixel integral
-        float H = 1.0f + (vx*vx + vy*vy - g->fxx - g->fyy) / 24.f; 
-        float C = g->amp * Gp * H; //count in this pixel. 
-        
-        residual -= C; 
+        float H = 1.0f + (vx*vx + vy*vy - g->fxx - g->fyy) / 24.f;
+        float C = g->amp * Gp * H; //count in this pixel.
+
+        residual -= C;
     }
     return residual;
 }
@@ -111,26 +111,26 @@ __device__ PixFloat ComputeResidualImage(float xp, float yp, PixFloat data, Imag
 // TODO: n_gal_gauss is a shared scalar in the calling function, but not here.
 // Can we avoid the thread-based storage?  Max's advice is probably not.
 
-__device__ void ComputeGaussianDerivative(float xp, float yp, float residual_ierr2, 
-            ImageGaussian *g, float * dchi2_dp, int n_gal_gauss) 
+__device__ void ComputeGaussianDerivative(float xp, float yp, float residual_ierr2,
+            ImageGaussian *g, float * dchi2_dp, int n_gal_gauss)
 {
-    // Loop over all gaussians in this galaxy. 
-    for (int gauss = 0; gauss<n_gal_gauss; gauss++, g++) {   
+    // Loop over all gaussians in this galaxy.
+    for (int gauss = 0; gauss<n_gal_gauss; gauss++, g++) {
         // ImageGaussian *g = gaussian+gauss;  // Now implicit in g++
-    
-        float dx = xp - g->xcen; 
-        float dy = yp - g->ycen; 
+
+        float dx = xp - g->xcen;
+        float dy = yp - g->ycen;
         float vx = g->fxx * dx + g->fxy * dy;
         float vy = g->fyy * dy + g->fxy * dx;
-        
-        float exparg = dx*vx + dy*vy; 
+
+        float exparg = dx*vx + dy*vy;
         if (exparg>(float)MAX_EXP_ARG) continue;
-        
+
         float Gp = expf(-0.5f * exparg);
-        float H = 1.0f + (vx*vx + vy*vy - g->fxx - g->fyy) *(1.0f/24.0f); 
-    
+        float H = 1.0f + (vx*vx + vy*vy - g->fxx - g->fyy) *(1.0f/24.0f);
+
         // Old code: this had divisions
-        // float C = residual_ierr2 * g->amp * Gp * H;   
+        // float C = residual_ierr2 * g->amp * Gp * H;
         // float dC_dA   = C / g->amp;
         // float c_h = C / H;
 
@@ -143,39 +143,39 @@ __device__ void ComputeGaussianDerivative(float xp, float yp, float residual_ier
         float dC_dfx  = -0.5f*C*dx*dx;
         float dC_dfy  = -0.5f*C*dy*dy;
         float dC_dfxy = -1.0f*C*dx*dy;
-    
+
         dC_dx    -= c_h * (g->fxx*vx + g->fxy*vy) * (1.0f/12.0f);
         dC_dy    -= c_h * (g->fyy*vy + g->fxy*vx) * (1.0f/12.0f);
         dC_dfx   -= c_h * (1.0f - 2.0f*dx*vx) * (1.0f/24.0f);
         dC_dfy   -= c_h * (1.0f - 2.0f*dy*vy) * (1.0f/24.0f);
         dC_dfxy  += c_h * (dy*vx + dx*vy) * (1.0f/12.0f);
-             
-        //Multiply by Jacobian and add to dchi2_dp    
-        dchi2_dp[0] += g->dA_dFlux * dC_dA ; 
+
+        //Multiply by Jacobian and add to dchi2_dp
+        dchi2_dp[0] += g->dA_dFlux * dC_dA ;
         dchi2_dp[1] += g->dx_dAlpha * dC_dx + g->dy_dAlpha * dC_dy;
         dchi2_dp[2] += g->dx_dDelta * dC_dx + g->dy_dDelta * dC_dy;
         dchi2_dp[3] += g->dA_dQ  * dC_dA + dC_dfx * g->dFxx_dQ + dC_dfxy * g->dFxy_dQ + dC_dfy * g->dFyy_dQ;
         dchi2_dp[4] += g->dA_dPA * dC_dA + dC_dfx * g->dFxx_dPA + dC_dfxy * g->dFxy_dPA + dC_dfy * g->dFyy_dPA;
         dchi2_dp[5] += g->dA_dSersic * dC_dA;
-        dchi2_dp[6] += g->dA_drh * dC_dA;    
+        dchi2_dp[6] += g->dA_drh * dC_dA;
     }
 }
 
 
 // =================== Code to prepare the Gaussians =======================
 
-/// This holds the information on a single source Gaussian, along with 
+/// This holds the information on a single source Gaussian, along with
 /// info needed to compute derivatives post-convolution.
 
-typedef struct { 
-    // 6 Gaussian parameters for sersic profile 
+typedef struct {
+    // 6 Gaussian parameters for sersic profile
     float amp;
     float xcen;
     float ycen;
-    float covar; //diagonal element of sersic profile covariance. covariance = covar * I. 
-    matrix22 scovar_im; 
-    
-    //some distortions and astrometry specific to ??source??. 
+    float covar; //diagonal element of sersic profile covariance. covariance = covar * I.
+    matrix22 scovar_im;
+
+    //some distortions and astrometry specific to ??source??.
     float flux;
     float G;
     float da_dn;
@@ -184,9 +184,9 @@ typedef struct {
     matrix22 T;
     matrix22 dT_dq;
     matrix22 dT_dpa;
-} PixGaussian; 
+} PixGaussian;
 
-/// This function takes a source Gaussian and a PSF Gaussian and 
+/// This function takes a source Gaussian and a PSF Gaussian and
 /// performs the convolution, creating the ImageGaussian that contains
 /// the on-image gaussian plus the Jacobian to convert derivatives into
 /// the on-sky parameters.
@@ -194,93 +194,93 @@ typedef struct {
 __device__ void  GetGaussianAndJacobian(PixGaussian & sersicgauss, PSFSourceGaussian & psfgauss, ImageGaussian & gauss){
 
     // sersicgauss.covar is the square of the radius; it's a scalar
-    sersicgauss.scovar_im = sersicgauss.covar * AAt(sersicgauss.T); 
-        
-    matrix22 covar = sersicgauss.scovar_im + matrix22(psfgauss.Cxx, psfgauss.Cxy, psfgauss.Cxy, psfgauss.Cyy); 
-    matrix22 f = covar.inv(); 
-    float detF = f.det(); 
-    
-    gauss.fxx = f.v11; 
-    gauss.fxy = f.v21; 
-    gauss.fyy = f.v22; 
-    
-    gauss.xcen = sersicgauss.xcen + psfgauss.xcen; 
-    gauss.ycen = sersicgauss.ycen + psfgauss.ycen; 
-    
+    sersicgauss.scovar_im = sersicgauss.covar * AAt(sersicgauss.T);
+
+    matrix22 covar = sersicgauss.scovar_im + matrix22(psfgauss.Cxx, psfgauss.Cxy, psfgauss.Cxy, psfgauss.Cyy);
+    matrix22 f = covar.inv();
+    float detF = f.det();
+
+    gauss.fxx = f.v11;
+    gauss.fxy = f.v21;
+    gauss.fyy = f.v22;
+
+    gauss.xcen = sersicgauss.xcen + psfgauss.xcen;
+    gauss.ycen = sersicgauss.ycen + psfgauss.ycen;
+
     float tmp = sersicgauss.G * psfgauss.amp * sqrtf(detF) * (1.0f/(2.0f*(float) M_PI));
     gauss.amp = tmp * sersicgauss.flux * sersicgauss.amp;
     // gauss.amp = sersicgauss.flux * sersicgauss.G * sersicgauss.amp * psfgauss.amp * sqrt(detF) * (1.0/(2.0*M_PI)) ;
 
     //now get derivatives of F
     matrix22 dSigma_dq  = sersicgauss.covar * symABt(sersicgauss.T, sersicgauss.dT_dq);
-    // (sersicgauss.T * sersicgauss.dT_dq.T()+ sersicgauss.dT_dq*sersicgauss.T.T()); 
+    // (sersicgauss.T * sersicgauss.dT_dq.T()+ sersicgauss.dT_dq*sersicgauss.T.T());
     matrix22 dSigma_dpa = sersicgauss.covar * symABt(sersicgauss.T, sersicgauss.dT_dpa);
-    // (sersicgauss.T * sersicgauss.dT_dpa.T()+sersicgauss.dT_dpa*sersicgauss.T.T()); 
-    
+    // (sersicgauss.T * sersicgauss.dT_dpa.T()+sersicgauss.dT_dpa*sersicgauss.T.T());
+
     matrix22 dF_dq      = -1.0f * ABA (f, dSigma_dq);  // F *  dSigma_dq * F
     matrix22 dF_dpa     = -1.0f * ABA (f, dSigma_dpa); // F * dSigma_dpa * F
-    
+
     // Now get derivatives with respect to sky parameters
-    // float ddetF_dq   = detF *  (covar * dF_dq).trace(); 
-    // float ddetF_dpa  = detF * (covar * dF_dpa).trace(); 
-    // gauss.dA_dQ      = gauss.amp /(2.0*detF) * ddetF_dq;  
-    // gauss.dA_dPA     = gauss.amp /(2.0*detF) * ddetF_dpa;  
+    // float ddetF_dq   = detF *  (covar * dF_dq).trace();
+    // float ddetF_dpa  = detF * (covar * dF_dpa).trace();
+    // gauss.dA_dQ      = gauss.amp /(2.0*detF) * ddetF_dq;
+    // gauss.dA_dPA     = gauss.amp /(2.0*detF) * ddetF_dpa;
     // Old code: Why do we multiply and then divide by detF?
 
     gauss.dA_dQ      = 0.5f*gauss.amp * (covar * dF_dq).trace();
     gauss.dA_dPA     = 0.5f*gauss.amp * (covar * dF_dpa).trace();
-    
+
     gauss.dA_dFlux      = tmp * sersicgauss.amp;
     gauss.dA_dSersic    = tmp * sersicgauss.flux * sersicgauss.da_dn;
     gauss.dA_drh        = tmp * sersicgauss.flux * sersicgauss.da_dr;
 
-    // gauss.dA_dFlux   = gauss.amp / sersicgauss.flux; 
+    // gauss.dA_dFlux   = gauss.amp / sersicgauss.flux;
     // gauss.dA_dSersic = gauss.amp / sersicgauss.amp * sersicgauss.da_dn;
     // gauss.dA_drh     = gauss.amp / sersicgauss.amp * sersicgauss.da_dr;
     // Old code: Some opportunity in the above to avoid some divisions.
-    
-    gauss.dx_dAlpha = sersicgauss.CW.v11; 
-    gauss.dy_dAlpha = sersicgauss.CW.v21; 
-    
+
+    gauss.dx_dAlpha = sersicgauss.CW.v11;
+    gauss.dy_dAlpha = sersicgauss.CW.v21;
+
     gauss.dx_dDelta = sersicgauss.CW.v12;
-    gauss.dy_dDelta = sersicgauss.CW.v22; 
-    
+    gauss.dy_dDelta = sersicgauss.CW.v22;
+
     gauss.dFxx_dQ = dF_dq.v11;
     gauss.dFyy_dQ = dF_dq.v22;
-    gauss.dFxy_dQ = dF_dq.v21; 
+    gauss.dFxy_dQ = dF_dq.v21;
 
     gauss.dFxx_dPA = dF_dpa.v11;
     gauss.dFyy_dPA = dF_dpa.v22;
-    gauss.dFxy_dPA = dF_dpa.v21; 
+    gauss.dFxy_dPA = dF_dpa.v21;
 }
 
-/// This function takes all of the sources for this exposure and 
+/// This function takes all of the sources for this exposure and
 /// convolves each with the PSFGaussians for all radii, producing a long
 /// set of ImageGaussians that live in the shared memory.
 
 __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposure, ImageGaussian * imageGauss) {
-    
+
     // We're going to store some values common to the exposure in shared memory
-    __shared__ int band, psfgauss_start, n_psf_per_source, n_gal_gauss; 
-    __shared__ float G, crpix[2], crval[2]; 
-    
+    __shared__ int band, psfgauss_start, n_psf_per_source, n_gal_gauss;
+    __shared__ float G, crpix[2], crval[2];
+
     // Load the shared values
     if ( threadIdx.x == 0 ){
         band = blockIdx.x;   // This block is doing one band
         psfgauss_start = patch->psfgauss_start[exposure];
-        G = patch->G[exposure]; 
-    
+        G = patch->G[exposure];
+
         crpix[0] = patch->crpix[2*exposure]; crpix[1] = patch->crpix[2*exposure + 1];
         crval[0] = patch->crval[2*exposure]; crval[1] = patch->crval[2*exposure + 1];
-    
-        n_psf_per_source = patch->n_psf_per_source[band]; //constant per band. 
+
+        n_psf_per_source = patch->n_psf_per_source[band]; //constant per band.
         n_gal_gauss = patch->n_sources * n_psf_per_source;
         // OPTION: Consider use of __constant__ variables
     }
-    
+
     __syncthreads();
-    
-    // And now we're ready for the main loop.  
+
+    // And now we're ready for the main loop.
     // Each thread will work on one ImageGaussian, which means one PSF component
     // and one source radius for one galaxy/source.
 
@@ -288,60 +288,60 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
         // Unpack the source and gaussian.
         int g = tid / n_psf_per_source;       // Source number
         int p = tid - g * n_psf_per_source;   // Gaussian number
-        
-        Source *galaxy = sources+g;     
-        PSFSourceGaussian *psfgauss = patch->psfgauss+psfgauss_start + p; 
+
+        Source *galaxy = sources+g;
+        PSFSourceGaussian *psfgauss = patch->psfgauss+psfgauss_start + p;
         PixGaussian    sersicgauss;    // This is where we'll queue up the source info
-    
-        // Do the setup of the transformations        
+
+        // Do the setup of the transformations
         //Get the transformation matrix and other conversions
-        matrix22 D, R, S; 
-        
-        int d_cw_start = 4 * (patch->n_sources * exposure + g); 
-        D  = matrix22(patch->D+d_cw_start);        
-        R.rot(galaxy->pa); 
-        S.scale(galaxy->q); 
-    
+        matrix22 D, R, S;
+
+        int d_cw_start = 4 * (patch->n_sources * exposure + g);
+        D  = matrix22(patch->D+d_cw_start);
+        R.rot(galaxy->pa);
+        S.scale(galaxy->q);
+
         //And its derivatives with respect to scene parameters
         matrix22 dS_dq, dR_dpa;
         dS_dq.scale_matrix_deriv(galaxy->q);
         dR_dpa.rotation_matrix_deriv(galaxy->pa);
-                
-        float smean[2]; 
+
+        float smean[2];
         smean[0] = galaxy->ra  - crval[0];
-        smean[1] = galaxy->dec - crval[1]; 
+        smean[1] = galaxy->dec - crval[1];
         sersicgauss.CW = matrix22(patch->CW+d_cw_start);
-        Av(sersicgauss.CW, smean); //multiplies CW (2x2) by smean (2x1) and stores result in smean. 
-        
-        int s = psfgauss->sersic_radius_bin; 
-        sersicgauss.xcen = smean[0] + crpix[0]; 
-        sersicgauss.ycen = smean[1] + crpix[1]; 
-        sersicgauss.covar = patch->rad2[s]; 
-        sersicgauss.amp   = galaxy->mixture_amplitudes[s]; 
+        Av(sersicgauss.CW, smean); //multiplies CW (2x2) by smean (2x1) and stores result in smean.
+
+        int s = psfgauss->sersic_radius_bin;
+        sersicgauss.xcen = smean[0] + crpix[0];
+        sersicgauss.ycen = smean[1] + crpix[1];
+        sersicgauss.covar = patch->rad2[s];
+        sersicgauss.amp   = galaxy->mixture_amplitudes[s];
         sersicgauss.da_dn = galaxy->damplitude_dnsersic[s];
-        sersicgauss.da_dr = galaxy->damplitude_drh[s] ; 
+        sersicgauss.da_dr = galaxy->damplitude_drh[s] ;
         sersicgauss.flux = galaxy->fluxes[band];         //pull the correct flux from the multiband array
         // G is the conversion of flux units to image counts
-        sersicgauss.G = G; 
+        sersicgauss.G = G;
         // T is a unit circle, stretched by q, rotated by PA, and then distorted to the pixel scale
-        sersicgauss.T = D * R * S; 
+        sersicgauss.T = D * R * S;
         // And now we have the derivatives of T wrt q and PA.
-        sersicgauss.dT_dq  = D * R * dS_dq; 
-        sersicgauss.dT_dpa = D * dR_dpa * S; 
+        sersicgauss.dT_dq  = D * R * dS_dq;
+        sersicgauss.dT_dpa = D * dR_dpa * S;
 
         GetGaussianAndJacobian(sersicgauss, *psfgauss, imageGauss[tid]);
             // g * n_psf_per_source + p]);
     }
 }
-    
-    
+
+
 
 // ===================== Helper class for accumulating the results ========
 
 class Accumulator {
   public:
     double chi2;
-    float dchi2_dp[NPARAMS*MAXSOURCES]; 
+    float dchi2_dp[NPARAMS*MAXSOURCES];
         //OPTION: Figure out how to make this not compile time.
 
     __device__ Accumulator() {
@@ -379,9 +379,9 @@ class Accumulator {
     __device__ void SumChi2(double _chi2) {
         warpReduceSumDbl(&chi2, _chi2);
     }
-    __device__ void SumDChi2dp(float *_dchi2_dp, int gal) { 
-        for (int j=0; j<NPARAMS; j++) 
-            warpReduceSum(dchi2_dp+NPARAMS*gal+j, _dchi2_dp[j]); 
+    __device__ void SumDChi2dp(float *_dchi2_dp, int gal) {
+        for (int j=0; j<NPARAMS; j++)
+            warpReduceSum(dchi2_dp+NPARAMS*gal+j, _dchi2_dp[j]);
     }
 
     /// This copies this Accumulator into another memory buffer
@@ -418,13 +418,13 @@ class Accumulator {
 // Creating a more interpretable shorthand for this
 
 extern "C" {
-__global__ void EvaluateProposal(void *_patch, void *_proposal, 
+__global__ void EvaluateProposal(void *_patch, void *_proposal,
                                  void *pchi2, void *pdchi2_dp) {
     // We will use a block of shared memory
     extern __shared__ char shared[];
 
     // Get the patch set up
-    Patch *patch = (Patch *)_patch;  
+    Patch *patch = (Patch *)_patch;
 
     // The Proposal is a vector of Sources[n_sources]
     Source *sources = (Source *)_proposal;
@@ -437,7 +437,7 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
     __shared__ int n_gauss_total;   // Number of image gaussians for all sources
     __shared__ ImageGaussian *imageGauss; // [source][gauss]
     __shared__ Accumulator *accum;   // [NUMACCUMS]
-    
+
     if (threadIdx.x==0) {
         int shared_counter = 0;
 
@@ -457,7 +457,7 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
 
     // Now figure out which one this thread should use
     int threads_per_accum = ceilf(blockDim.x/warpSize/NUMACCUMS)*warpSize;
-    int accumnum = threadIdx.x / threads_per_accum;  // We are accumulating each warp separately. 
+    int accumnum = threadIdx.x / threads_per_accum;  // We are accumulating each warp separately.
 
     // Loop over Exposures
     for (int e = 0; e < band_N; e++) {
@@ -466,7 +466,7 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
         CreateImageGaussians(patch, sources, exposure, imageGauss);
 
         __syncthreads();
-    
+
         for (int p = threadIdx.x ; p < patch->exposure_N[exposure]; p += blockDim.x) {
             int pix = patch->exposure_start[exposure] + p;
 
@@ -498,7 +498,7 @@ __global__ void EvaluateProposal(void *_patch, void *_proposal,
             for (int gal = 0; gal < n_sources; gal++) {
                 for (int j=0; j<NPARAMS; j++) dchi2_dp[j]=0.0f;
                 ComputeGaussianDerivative(xp, yp, residual,  //1.
-                        imageGauss+gal*n_gal_gauss, dchi2_dp, n_gal_gauss);  
+                        imageGauss+gal*n_gal_gauss, dchi2_dp, n_gal_gauss);
 
                 //if(gal == 0)
                 //    patch->residual[pix] = dchi2_dp[1];

--- a/forcepho/src/compute_gaussians_kernel.cu
+++ b/forcepho/src/compute_gaussians_kernel.cu
@@ -262,7 +262,7 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
 
     // We're going to store some values common to the exposure in shared memory
     __shared__ int band, psfgauss_start, n_psf_per_source, n_gal_gauss;
-    __shared__ float G, crpix[2], crval[2];
+    __shared__ float G //, crpix[2], crval[2];
 
     // Load the shared values
     if ( threadIdx.x == 0 ){
@@ -270,8 +270,8 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
         psfgauss_start = patch->psfgauss_start[exposure];
         G = patch->G[exposure];
 
-        crpix[0] = patch->crpix[2*exposure]; crpix[1] = patch->crpix[2*exposure + 1];
-        crval[0] = patch->crval[2*exposure]; crval[1] = patch->crval[2*exposure + 1];
+        //crpix[0] = patch->crpix[2*exposure]; crpix[1] = patch->crpix[2*exposure + 1];
+        //crval[0] = patch->crval[2*exposure]; crval[1] = patch->crval[2*exposure + 1];
 
         n_psf_per_source = patch->n_psf_per_source[band]; //constant per band.
         n_gal_gauss = patch->n_sources * n_psf_per_source;
@@ -298,7 +298,7 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
         matrix22 D, R, S;
 
         int d_cw_start = 4 * (patch->n_sources * exposure + g);
-        D  = matrix22(patch->D+d_cw_start);
+        D = matrix22(patch->D+d_cw_start);
         R.rot(galaxy->pa);
         S.scale(galaxy->q);
 
@@ -306,6 +306,12 @@ __device__ void CreateImageGaussians(Patch * patch, Source * sources, int exposu
         matrix22 dS_dq, dR_dpa;
         dS_dq.scale_matrix_deriv(galaxy->q);
         dR_dpa.rotation_matrix_deriv(galaxy->pa);
+
+        // Source dependent coordinate reference values
+        float crpix[2], crval[2];
+        int cr_start = 2 * (patch->n_sources * exposure + g);
+        crpix = patch->crpix+cr_start;
+        crval = patch->crval+cr_start;
 
         float smean[2];
         smean[0] = galaxy->ra  - crval[0];

--- a/forcepho/src/header.hh
+++ b/forcepho/src/header.hh
@@ -8,7 +8,7 @@
 #define CUDA_CALLABLE_MEMBER __host__ __device__
 #else
 #define CUDA_CALLABLE_MEMBER
-#endif 
+#endif
 
 #include "kernel_limits.h"
 

--- a/forcepho/src/kernel_limits.h
+++ b/forcepho/src/kernel_limits.h
@@ -1,15 +1,15 @@
-// This file contains numerical limits that we have to hardwire to 
+// This file contains numerical limits that we have to hardwire to
 // ease fixed-sized allocations on the GPU
 
 // The maximum number of bands we're allowed to use
-#define MAXBANDS 30     
+#define MAXBANDS 30
 
 // The maximum number of active sources that the GPU can use
-#define MAXSOURCES 30   
+#define MAXSOURCES 30
 
 // The number of on-sky parameters per band that yield derivatives
 #define NPARAMS 7
-// NOTE: Changing this *also* requires changing the structure of 
+// NOTE: Changing this *also* requires changing the structure of
 // the ImageGaussian class and the computation of the derivatives.
 
 // The maximum square distance in a Gaussian evaluation before we no-op.
@@ -28,7 +28,7 @@
 
 // Shared memory in each GPU block is limited to 48 KB, which is 12K floats.
 // We have a handful (~9) of single variables, and then the big items are:
-// The accumulators are NUMACCUMS*(NPARAMS*MAXSOURCES+1) shared floats 
+// The accumulators are NUMACCUMS*(NPARAMS*MAXSOURCES+1) shared floats
 // The ImageGaussians are n_psf_per_source*n_sources*21 shared floats,
 // so this is bounded by n_psf_per_source*MAXSOURCES*21.
 

--- a/forcepho/src/matrix22.cc
+++ b/forcepho/src/matrix22.cc
@@ -1,6 +1,6 @@
 /* matrix22.cc
 This creates a simple class for 2x2 real-valued matrices.
-Convention: 
+Convention:
     v11 v12
     v21 v22
 
@@ -26,7 +26,7 @@ CUDA_CALLABLE_MEMBER inline matrix22 operator * (const matrix22& A, const matrix
 */
 
 
-	
+
 
 
 class matrix22 {
@@ -49,7 +49,7 @@ class matrix22 {
     CUDA_CALLABLE_MEMBER matrix22(const float d[]) {
         v11 = d[0]; v12 = d[1]; v21 = d[2]; v22 = d[3];
     }
-	
+
 	CUDA_CALLABLE_MEMBER inline void debug_print(){
 		printf(" %f %f\n", v11, v12);
 		printf(" %f %f\n\n", v21, v22);
@@ -71,17 +71,17 @@ class matrix22 {
         float c = cos(theta); float s = sin(theta);
         v11 = v22 = c;  v12 = -s; v21 = s;
     }
-    
+
     CUDA_CALLABLE_MEMBER inline void rotation_matrix_deriv(float theta){
         float c = cos(theta); float s = sin(theta);
-        v11 = v22 = -s; v12 = -c; v21 = c; 
+        v11 = v22 = -s; v12 = -c; v21 = c;
         // return matrix22( -s, -c, c, -s);
     }
-    
+
     CUDA_CALLABLE_MEMBER inline void scale(float q) {
         v11 = 1.0f/q; v22 = q; v12 = v21 = 0.0;
     }
-    
+
     CUDA_CALLABLE_MEMBER inline void scale_matrix_deriv(float q){
         v11 = -1.0f/(q*q); v22 = 1.0; v12 = v21 = 0.0;
         // return matrix22(-1.0/(q*q), 1.0);
@@ -90,7 +90,7 @@ class matrix22 {
     // --------------------------------------------------
     // The following operations return a new output matrix
     // The input instance is not altered
-    
+
     /// The transpose
     CUDA_CALLABLE_MEMBER inline matrix22 T() { return matrix22(v11, v21, v12, v22); }
 
@@ -106,7 +106,7 @@ class matrix22 {
         return matrix22(v22*idet, -v12*idet, -v21*idet, v11*idet);
     }
 
-    // matrix *= scalar 
+    // matrix *= scalar
     CUDA_CALLABLE_MEMBER inline matrix22& operator *= ( const float s) {
         v11*=s; v12*=s; v21*=s; v22*=s; return *this;
     }
@@ -126,10 +126,10 @@ CUDA_CALLABLE_MEMBER inline matrix22 operator * (const float s, const matrix22& 
 
 /// matrix + matrix, matrix - matrix
 CUDA_CALLABLE_MEMBER inline matrix22 operator + (const matrix22& A, const matrix22& B) {
-    return matrix22( A.v11+B.v11, A.v12+B.v12, A.v21+B.v21, A.v22+B.v22); 
+    return matrix22( A.v11+B.v11, A.v12+B.v12, A.v21+B.v21, A.v22+B.v22);
 }
 CUDA_CALLABLE_MEMBER inline matrix22 operator - (const matrix22& A, const matrix22& B) {
-    return matrix22( A.v11-B.v11, A.v12-B.v12, A.v21-B.v21, A.v22-B.v22); 
+    return matrix22( A.v11-B.v11, A.v12-B.v12, A.v21-B.v21, A.v22-B.v22);
 }
 
 /// matrix * matrix product
@@ -141,12 +141,12 @@ CUDA_CALLABLE_MEMBER inline matrix22 operator * (const matrix22& A, const matrix
 // ========== And here are functions that work on matrices ===========
 
 ///Compute A B A, return matrix
-CUDA_CALLABLE_MEMBER inline matrix22 ABA(const matrix22& A, matrix22& B){ //mamma mia! 
-	float v11 = A.v11 * A.v11 * B.v11 + A.v11 * A.v21 * B.v12 + A.v11 * A.v12 * B.v21 + A.v12 * A.v21 * B.v22; 	
-    float v12 = A.v11 * A.v12 * B.v11 + A.v11 * A.v22 * B.v12 + A.v12 * A.v12 * B.v21 + A.v12 * A.v22 * B.v22; 	
-    float v21 = A.v11 * A.v21 * B.v11 + A.v21 * A.v21 * B.v12 + A.v11 * A.v22 * B.v21 + A.v21 * A.v22 * B.v22; 	
-    float v22 = A.v12 * A.v21 * B.v11 + A.v21 * A.v22 * B.v12 + A.v12 * A.v22 * B.v21 + A.v22 * A.v22 * B.v22; 
-    return matrix22(v11, v12, v21, v22); 
+CUDA_CALLABLE_MEMBER inline matrix22 ABA(const matrix22& A, matrix22& B){ //mamma mia!
+	float v11 = A.v11 * A.v11 * B.v11 + A.v11 * A.v21 * B.v12 + A.v11 * A.v12 * B.v21 + A.v12 * A.v21 * B.v22;
+    float v12 = A.v11 * A.v12 * B.v11 + A.v11 * A.v22 * B.v12 + A.v12 * A.v12 * B.v21 + A.v12 * A.v22 * B.v22;
+    float v21 = A.v11 * A.v21 * B.v11 + A.v21 * A.v21 * B.v12 + A.v11 * A.v22 * B.v21 + A.v21 * A.v22 * B.v22;
+    float v22 = A.v12 * A.v21 * B.v11 + A.v21 * A.v22 * B.v12 + A.v12 * A.v22 * B.v21 + A.v22 * A.v22 * B.v22;
+    return matrix22(v11, v12, v21, v22);
 }
 
 /// Compute A A^T, return the symmetrix matrix
@@ -188,13 +188,13 @@ CUDA_CALLABLE_MEMBER inline float vtAv(matrix22& A, float v1, float v2) {
 /// A matrix * vector product, returning in place
 CUDA_CALLABLE_MEMBER inline void Av(matrix22& A, float *v) {
     float v1 = v[0]; float v2 = v[1];
-    v[0] = A.v11 * v1 + A.v12 * v2; 
-    v[1] = A.v21 * v1 + A.v22 * v2; 
+    v[0] = A.v11 * v1 + A.v12 * v2;
+    v[1] = A.v21 * v1 + A.v22 * v2;
 }
 
 /// A matrix * vector product, returning out of place
 CUDA_CALLABLE_MEMBER inline void Av(float *w, matrix22& A, float *v) {
     float v1 = v[0]; float v2 = v[1];
-    w[0] = A.v11 * v1 + A.v12 * v2; 
-    w[1] = A.v21 * v1 + A.v22 * v2; 
+    w[0] = A.v11 * v1 + A.v12 * v2;
+    w[1] = A.v21 * v1 + A.v22 * v2;
 }

--- a/forcepho/src/patch.cu
+++ b/forcepho/src/patch.cu
@@ -24,7 +24,7 @@ class Patch {
 public:
 
     /* Image info */
-    
+
     // Pixel data -- all exposures, all bands
     // Note that the pixels are organized into warp-sized compact superpixels
     // and exposures are padded to blockDim.x.
@@ -40,13 +40,13 @@ public:
 
     // These index the pixel arrays
     int *exposure_start;    // [expnum]. This exposure's pixels start at exposure_start[exposure]
-    int *exposure_N;        // [expnum]. This exposure has exposure_N[exposure] pixels. 
+    int *exposure_N;        // [expnum]. This exposure has exposure_N[exposure] pixels.
 
     // These index the exposure_start and exposure_N arrays
     // bands are indexed sequentially, not by any band ID
     // These are the expnum used elsewhere
     int16_t *band_start;    // [band]. This band's exposures start at band_start[band].
-    int16_t *band_N;        // [band]. This band has band_N[band] exposures. 
+    int16_t *band_N;        // [band]. This band has band_N[band] exposures.
 
     // ------------------ Source data --------------------
     // Number of active sources
@@ -57,7 +57,7 @@ public:
     int n_radii;
 
     // The square radii of the Sersic mixtures (in arcsec^2)
-    float *rad2;   //[n_radii] 
+    float *rad2;   //[n_radii]
 
     // ----------------------- Astrometry --------------------
     // Astrometry: scale, rotation matrices (and derivatives)
@@ -66,7 +66,7 @@ public:
     //      D[4*nsource*exposure + 4*source + 2*i + j]
     // (could also be an array of matrix structs if preferred)
     // The exposure indices for a band can be found from band_start and band_N
-    
+
     // D is pixels per arcsec, d(pixel x,y)/d(sky).
     // Here the sky is in arcseconds of displacement, which differs from CW
     // because of a cos(dec)
@@ -74,13 +74,13 @@ public:
 
     // The Coordinate Reference Point has a pixel location and a RA/Dec
     float *crpix;   // [expnum][2] -- Image pixel
-    float *crval;   // [expnum][2] -- RA/Dec 
+    float *crval;   // [expnum][2] -- RA/Dec
 
     // CW is d(pixel x,y)/d(RA,dec) expanded around CR point
     float *CW;      // [expnum][source][2][2]
 
     // G is the conversion from our sky flux scale into exposure counts
-    float *G;       // [expnum]  
+    float *G;       // [expnum]
 
 
     // --------------  PSF Gaussians  ---------------------
@@ -114,8 +114,8 @@ public:
 
     // The index of the sersic radius bin this Gaussian applies to
     int sersic_radius_bin;
-	
-	
+
+
 };
 
 #endif

--- a/forcepho/src/patch.cu
+++ b/forcepho/src/patch.cu
@@ -73,8 +73,8 @@ public:
     float *D;       // [expnum][source][2][2]
 
     // The Coordinate Reference Point has a pixel location and a RA/Dec
-    float *crpix;   // [expnum][2] -- Image pixel
-    float *crval;   // [expnum][2] -- RA/Dec
+    float *crpix;   // [expnum][source][2] -- Image pixel
+    float *crval;   // [expnum][source][2] -- RA/Dec
 
     // CW is d(pixel x,y)/d(RA,dec) expanded around CR point
     float *CW;      // [expnum][source][2][2]

--- a/forcepho/src/proposal.cu
+++ b/forcepho/src/proposal.cu
@@ -1,6 +1,6 @@
 /* proposal.cu
 
-This is the data model for the Source class on the GPU.  
+This is the data model for the Source class on the GPU.
 A proposal consists of a list of Sources.
 Similarly, the response for the likelihood derivatives is a Band-length
 vector of Response's.
@@ -27,14 +27,14 @@ class Source {
 };
 
 
-/// The response from the GPU likelihood call kernel for for a single band for a single proposal.  A full response will consist of a list of NBANDS of these responses.  
-/// There can be many empty elements of this if MAXSOURCE > NSOURCE 
+/// The response from the GPU likelihood call kernel for for a single band for a single proposal.  A full response will consist of a list of NBANDS of these responses.
+/// There can be many empty elements of this if MAXSOURCE > NSOURCE
 /// For HMC, need to pull out every NPARAMth element for the fluxes and then coadd the remaining shape gradients across bands
 class Response {
   public:
     // This is the gradients for all sources in a patch in a band
     // It is ordered d/dflux, d/dra, d/dec, d/dq, d/dpa, d/dsersic, d/drh
-    // and then repeats for each source. 
+    // and then repeats for each source.
     float dchi2_dparam[MAXSOURCES * NPARAMS];
 };
 


### PR DESCRIPTION
WIP: Add source specific crpix/crval pairs to the meta data used on the GPU side.  This will make the local WCS affine transformations valid when distortions are present (since we use source specific scale and CD matrices)